### PR TITLE
#167333919 Implement users can filter trips based on destination endpoint using postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ ___
 bookings.
 8. Users can delete their booking.
 9. Users can specify their seat numbers when making a booking.
+10. Users can get a list of filtered trips based on destination.
 
 ___
 
@@ -60,6 +61,7 @@ The API endpoints are hosted on Heroku - [WAY-FARER](https://way-farerapp.heroku
 |POST    |Sign In                            |/api/v1/auth/signin                        |
 |POST    |Create a trip           |/api/v1/trips                         |
 |GET   | Get all trips           | /api/v1/trips  |
+|GET   | Filter trips based on destination           | /api/v1/trips?destination={destination}  |
 |POST    | Book a seat on a trip        | /api/v1/bookings  |
 |GET    | View all bookings                | /api/v1/bookings   |
 |DELETE   | Delete a booking                    | /api/v1/bookings/:bookingId   |

--- a/server/helpers/objectUtils.js
+++ b/server/helpers/objectUtils.js
@@ -53,4 +53,15 @@ export default class ObjectUtils {
     seatNumber = filtered[randomSeat];
     return seatNumber;
   }
+
+  static convertStringToTitle(word) {
+    const sentence = word.split(' ');
+    const container = [];
+    let currentString = '';
+    sentence.map((values) => {
+      currentString = values.charAt(0).toUpperCase() + values.slice(1);
+      container.push(currentString);
+    });
+    return container.join(' ');
+  }
 }

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -134,4 +134,18 @@ export default class validator {
         error: errors.map(err => err.msg),
       }));
   }
+
+  static viewTrips(req, res, next) {
+    req.checkQuery('destination').optional()
+      .isLength({ min: 1 })
+      .withMessage('Destination should have more than one character.')
+      .matches(/^[a-zA-Z]+(?:[\s-][a-zA-Z]+)*$/)
+      .withMessage('Destination does not match.');
+    req.asyncValidationErrors()
+      .then(next)
+      .catch(errors => res.status(400).json({
+        status: 'error',
+        error: errors.map(err => err.msg),
+      }));
+  }
 }

--- a/server/model/trips.js
+++ b/server/model/trips.js
@@ -4,6 +4,8 @@ const tripQueries = {
 
   getAllTrips: 'SELECT id, bus_id, origin, destination, trip_date, fare FROM trip',
 
+  filterTripsByDestination: 'SELECT id, bus_id, origin, destination, trip_date, fare FROM trip WHERE destination = $1',
+
   cancelTrip: 'UPDATE trip SET active = $1 WHERE id = $2',
 
   getTrip: 'SELECT * FROM trip WHERE id = $1',

--- a/server/router/tripRouter.js
+++ b/server/router/tripRouter.js
@@ -9,11 +9,11 @@ const router = express.Router();
 const { createTrip, getAllTrips, cancelTrip } = tripController;
 const { verifyToken } = jwtUtils;
 const { isAdmin, isBusExist, isTripExist } = authentication;
-const { tripValidation, tripIdParams } = validator;
+const { tripValidation, tripIdParams, viewTrips } = validator;
 
 router.post('/trips', tripValidation, verifyToken, isAdmin, isBusExist, createTrip);
 
-router.get('/trips', verifyToken, getAllTrips);
+router.get('/trips', viewTrips, verifyToken, getAllTrips);
 
 router.patch('/trips/:id', tripIdParams, isTripExist, verifyToken, isAdmin, cancelTrip);
 

--- a/server/test/tripRoute.js
+++ b/server/test/tripRoute.js
@@ -159,6 +159,25 @@ describe('Get Trip', () => {
     assert.property((res.body), 'error');
   });
 
+  it('Should return an error for unmatched destination', async () => {
+    const res = await request
+      .get('/api/v1/trips?destination=gtt123')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'error');
+    assert.property((res.body), 'error');
+  });
+
+  it('Should return the trip array of object based on the destination', async () => {
+    const res = await request
+      .get('/api/v1/trips?destination=new york')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'success');
+    assert.property((res.body), 'status');
+    assert.property((res.body), 'data');
+  });
+
   it('Should return the trip array of object', async () => {
     const res = await request
       .get('/api/v1/trips')


### PR DESCRIPTION
#### What does this PR do?
This PR implements filter trips based on destination endpoint for Way-Farer
#### Description of Task to be completed?
Have the endpoint working
`GET /api/v1/trips?destination=<destination>`
#### How should this be manually tested?
After cloning this repository, cd into it and RUN `npm test` or `npm run start:dev` in the terminal or cmd
- Using postman test the endpoint above with this header
key: Content-Type value: application/x-www-form-urlencoded
#### Any background context you want to provide?
An endpoint for the user to filter the trips based on the destination was not implemented, hence filter trips based on destination endpoint was implemented in order to give the user the privilege to search for trips based on the destination.  
#### What are the relevant PT stories?
(#167333919)[https://www.pivotaltracker.com/n/projects/2359698]