### PR TITLE
#167333895 Implement users can filter trips based on origin endpoint using postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ bookings.
 8. Users can delete their booking.
 9. Users can specify their seat numbers when making a booking.
 10. Users can get a list of filtered trips based on destination.
+11. Users can get a list of filtered trips based on origin.
 
 ___
 
@@ -62,6 +63,7 @@ The API endpoints are hosted on Heroku - [WAY-FARER](https://way-farerapp.heroku
 |POST    |Create a trip           |/api/v1/trips                         |
 |GET   | Get all trips           | /api/v1/trips  |
 |GET   | Filter trips based on destination           | /api/v1/trips?destination={destination}  |
+|GET   | Filter trips based on origin           | /api/v1/trips?origin={origin}  |
 |POST    | Book a seat on a trip        | /api/v1/bookings  |
 |GET    | View all bookings                | /api/v1/bookings   |
 |DELETE   | Delete a booking                    | /api/v1/bookings/:bookingId   |

--- a/server/controller/tripController.js
+++ b/server/controller/tripController.js
@@ -7,6 +7,7 @@ const { query } = db;
 const { convertStringToTitle } = objectUtils;
 const {
   createTrip, getAllTrips, cancelTrip, filterTripsByDestination,
+  filterTripsByOrigin,
 } = trip;
 
 export default class TripController {
@@ -41,10 +42,17 @@ export default class TripController {
   }
 
   static async getAllTrips(req, res, next) {
-    const { destination } = req.query;
+    const { destination, origin } = req.query;
     try {
       if (typeof (destination) !== 'undefined') {
         const { rows } = await query(filterTripsByDestination, [convertStringToTitle(destination)]);
+        if (rows.length < 1) {
+          return res.status(404).json({ status: 'error', error: 'Trips not found' });
+        }
+        return res.status(200).json({ status: 'success', data: rows });
+      }
+      if (typeof (origin) !== 'undefined') {
+        const { rows } = await query(filterTripsByOrigin, [convertStringToTitle(origin)]);
         if (rows.length < 1) {
           return res.status(404).json({ status: 'error', error: 'Trips not found' });
         }

--- a/server/middleware/validator.js
+++ b/server/middleware/validator.js
@@ -141,6 +141,11 @@ export default class validator {
       .withMessage('Destination should have more than one character.')
       .matches(/^[a-zA-Z]+(?:[\s-][a-zA-Z]+)*$/)
       .withMessage('Destination does not match.');
+    req.checkQuery('origin').optional()
+      .isLength({ min: 1 })
+      .withMessage('Origin should have more than one character.')
+      .matches(/^[a-zA-Z]+(?:[\s-][a-zA-Z]+)*$/)
+      .withMessage('Origin does not match.');
     req.asyncValidationErrors()
       .then(next)
       .catch(errors => res.status(400).json({

--- a/server/model/trips.js
+++ b/server/model/trips.js
@@ -6,6 +6,8 @@ const tripQueries = {
 
   filterTripsByDestination: 'SELECT id, bus_id, origin, destination, trip_date, fare FROM trip WHERE destination = $1',
 
+  filterTripsByOrigin: 'SELECT id, bus_id, origin, destination, trip_date, fare FROM trip WHERE origin = $1',
+
   cancelTrip: 'UPDATE trip SET active = $1 WHERE id = $2',
 
   getTrip: 'SELECT * FROM trip WHERE id = $1',

--- a/server/test/tripRoute.js
+++ b/server/test/tripRoute.js
@@ -168,9 +168,64 @@ describe('Get Trip', () => {
     assert.property((res.body), 'error');
   });
 
+  it('Should return an error 404', async () => {
+    const res = await request
+      .get('/api/v1/trips?destination=netherland')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'error');
+    assert.property((res.body), 'error');
+  });
+
+  it('Should return an error small length', async () => {
+    const res = await request
+      .get('/api/v1/trips?destination=')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'error');
+    assert.property((res.body), 'error');
+  });
+
   it('Should return the trip array of object based on the destination', async () => {
     const res = await request
       .get('/api/v1/trips?destination=new york')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'success');
+    assert.property((res.body), 'status');
+    assert.property((res.body), 'data');
+  });
+
+  it('Should return an error for unmatched origin', async () => {
+    const res = await request
+      .get('/api/v1/trips?origin=gtt123')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'error');
+    assert.property((res.body), 'error');
+  });
+
+  it('Should return an error 404', async () => {
+    const res = await request
+      .get('/api/v1/trips?origin=netherland')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'error');
+    assert.property((res.body), 'error');
+  });
+
+  it('Should return an error small length', async () => {
+    const res = await request
+      .get('/api/v1/trips?origin=')
+      .set('Token', userToken)
+      .send(data.createTrip);
+    assert.equal((res.body.status), 'error');
+    assert.property((res.body), 'error');
+  });
+
+  it('Should return the trip array of object based on the destination', async () => {
+    const res = await request
+      .get('/api/v1/trips?origin=abuja')
       .set('Token', userToken)
       .send(data.createTrip);
     assert.equal((res.body.status), 'success');


### PR DESCRIPTION
#### What does this PR do?
This PR implements filter trips based on origin endpoint for Way-Farer
#### Description of Task to be completed?
Have the endpoint working
`GET /api/v1/trips?origin=<origin>`
#### How should this be manually tested?
After cloning this repository, cd into it and RUN `npm test` or `npm run start:dev` in the terminal or cmd
- Using postman test the endpoint above with this header
key: Content-Type value: application/x-www-form-urlencoded
#### Any background context you want to provide?
An endpoint for the user to filter the trips based on the origin was not implemented, hence filter trips based on origin endpoint was implemented in order to give the user the privilege to search for trips based on the origin.  
#### What are the relevant PT stories?
(#167333895)[https://www.pivotaltracker.com/n/projects/2359698]